### PR TITLE
Issue 11: Add GitHub Actions workflow for documentation build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       statuses: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,32 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    tags: '*'
+  pull_request:
+
+jobs:
+  build:
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: read
+      statuses: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1'
+      - uses: julia-actions/cache@v2
+      - name: Install dependencies
+        shell: julia --color=yes --project=docs {0}
+        run: |
+          using Pkg
+          Pkg.instantiate()
+      - name: Build and deploy
+        run: julia --color=yes --project=docs docs/make.jl
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -16,7 +16,6 @@ makedocs(
         "Getting started" => "vignettes/tutorial.md",
         "API Reference" => "api.md",
     ],
-    # repo = "https://github.com/CDCgov/NowcastAutoGP/",
     clean = false,
     checkdocs = :exports,
     remotes = nothing


### PR DESCRIPTION
Introduces a GitHub Actions workflow to automatically build and deploy documentation on push and pull request events. Also removes a commented-out repo URL from docs/make.jl for cleanup.