### PR TITLE
Issue 24: Add dark mode and theme support to `docs/src/assets/material-theme.css`

### DIFF
--- a/docs/src/assets/material-theme.css
+++ b/docs/src/assets/material-theme.css
@@ -573,7 +573,7 @@ html.theme--documenter-dark #documenter .hljs-addition,
 html.theme--documenter-dark #documenter .hljs-variable,
 html.theme--documenter-dark #documenter .hljs-template-tag,
 html.theme--documenter-dark #documenter .hljs-template-variable {
-  color: #81c995; /* Lighter green for dark mode */
+  color: #81c785; /* Lighter green for dark mode */
 }
 
 html.theme--documenter-dark #documenter .hljs-number,


### PR DESCRIPTION
This pull request updates the `material-theme.css` file to add comprehensive dark mode support for documentation themes and improves syntax highlighting for code blocks in dark mode. The changes ensure that Material Design color tokens and syntax highlighting are visually optimized for both light and dark themes, including support for Catppuccin variants and automatic system dark mode detection.

**Dark mode support and theme enhancements:**

* Added explicit dark mode color variables for the `documenter-dark` and Catppuccin themes, ensuring consistent Material Design color tokens in dark environments.
* Implemented auto dark mode support using the `prefers-color-scheme: dark` media query for users who have not set a theme explicitly.
* Updated comments and organization to clarify which color tokens apply to light and dark modes. [[1]](diffhunk://#diff-4aa042939715b6aa5fd0e837964e608012808113d1d7d3c16f35e73b0f2826bdL5-R5) [[2]](diffhunk://#diff-4aa042939715b6aa5fd0e837964e608012808113d1d7d3c16f35e73b0f2826bdL442-R492)

**Syntax highlighting improvements:**

* Replaced Julia-specific code highlighting with generalized dark mode syntax highlighting rules, providing better readability for code blocks in dark themes.