### PR TITLE
Fix: Improve type handling in transformation functions

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,7 +14,7 @@ makedocs(
     pages = [
         "Home" => "index.md",
         "Getting started" => "vignettes/tutorial.md",
-        "API Reference" => "api.md",
+        "API Reference" => "api.md"
     ],
     clean = true,
     checkdocs = :exports
@@ -22,5 +22,5 @@ makedocs(
 
 deploydocs(
     repo = "github.com/CDCgov/NowcastAutoGP.git",
-    devbranch = "main",
+    devbranch = "main"
 )


### PR DESCRIPTION
This PR fixes a problem where Integer data with zeros meant that the offset couldn't be coerced to a float value. I've extended this to be eltype stable with (e.g. Float32) floats and not for integers. Added tests to capture the failure.

This pull request improves the robustness and flexibility of transformation functions in the codebase, especially for handling integer and floating-point input data, including edge cases with zeros. It also adds comprehensive tests to ensure type stability and correct round-trip transformations for various data types.

### Transformation logic improvements

* Updated `_get_offset` to support both `AbstractFloat` and `Integer` types, ensuring correct offset calculation and type handling for non-negative values, including those with zeros.
* Refactored `_inv_boxcox` to consistently handle type conversion and edge cases, and fixed variable naming for clarity and correctness. [[1]](diffhunk://#diff-2a8ad864637520c3bd54334dd5de5b99568bd5b1be197744649fb0c0ddbbfbccL6-R13) [[2]](diffhunk://#diff-2a8ad864637520c3bd54334dd5de5b99568bd5b1be197744649fb0c0ddbbfbccL32-R32)

### Expanded test coverage

* Added extensive tests for Box-Cox, positive, and percentage transformations with integer and float data, including cases with zeros, to verify round-trip accuracy and type preservation.
* Introduced tests specifically for type preservation with `Float32` inputs and for correct handling of integer values with zeros, covering transformation and inverse transformation functions.

### Minor improvements

* Improved formatting and readability in test definitions and transformation function returns. [[1]](diffhunk://#diff-faf2282500fe67b688071a3fea680a0e9d70e31ab5c605a0f0942008fa1673d2L147-R148) [[2]](diffhunk://#diff-2a8ad864637520c3bd54334dd5de5b99568bd5b1be197744649fb0c0ddbbfbccL134-R141)
* Minor formatting consistency fixes in documentation build configuration.
* Removed extraneous blank line in test file for clarity.