### PR TITLE
Trim pre-commit to Julia-appropriate hooks

### DIFF
--- a/.github/actions/pre-commit/action.yaml
+++ b/.github/actions/pre-commit/action.yaml
@@ -16,7 +16,6 @@ runs:
     with:
       path: |
         ~/.cache/pre-commit
-        ~/.cache/R/renv
       key: pre-commit-4|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
   - run: SKIP=runic pre-commit run --show-diff-on-failure --color=always ${{ inputs.extra_args }}
     shell: bash

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,9 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - uses: actions/setup-python@v6
-    - uses: r-lib/actions/setup-r@v2
-      with:
-        use-public-rspm: true
     - uses: ./.github/actions/pre-commit
   runic:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,34 +11,6 @@ repos:
     -   id: mixed-line-ending
     -   id: trailing-whitespace
 #####
-# Python
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.10
-  hooks:
-    # Sort imports
-    - id: ruff
-      args: ['check', '--select', 'I', '--fix']
-    # Run the linter
-    - id: ruff
-      args: ['--line-length', '79']
-    # Run the formatter
-    - id: ruff-format
-      args: ['--line-length', '79']
-#####
-# R
--   repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.4.3.9009
-    hooks:
-    -   id: lintr
-#####
-# Java
-- repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v2.14.0
-  hooks:
-  - id: pretty-format-java
-    args: [--aosp,--autofix]
-
-#####
 # Secrets
 -   repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
@@ -46,3 +18,8 @@ repos:
     -   id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
         exclude: package.lock.json
+# NOTE: This is a Julia package. Julia formatting is handled by the separate
+# `runic` CI job (fredrikekre/runic-action). The previous Python (ruff), R
+# (lintr) and Java (pretty-format-java) hooks were removed: there are no such
+# source files in this repo, and the R `lintr` hook in particular bootstrapped
+# an renv library on every cold cache, which dominated pre-commit CI runtime.


### PR DESCRIPTION
## Why

Pre-commit CI on this repo is very slow. The cause isn't any recent change — it's hook **environment setup**. `pre-commit run --all-files` builds every hook's environment before running, regardless of whether matching files exist. This is a Julia package with **no `.py`, `.R`, or `.java` files**, yet the config installed hooks for all three:

- **R `lintr`** (`lorenzwalthert/precommit`) — bootstraps an `renv` library and compiles `lintr` + its dependency tree. Several minutes on a cold cache, and there's nothing to lint. This is the dominant cost.
- **`pretty-format-java`** — needs a Java formatter; no Java files.
- **ruff ×3** (Python) — builds a venv; no Python files.

Cold rebuilds happen easily because the cache key (`pre-commit-4|${pythonLocation}|hashFiles(config)`) has no `restore-keys` fallback.

## What

- Remove the ruff, lintr, and pretty-format-java hooks. Keep the generic file-cleanliness hooks + `detect-secrets`.
- Julia formatting is unchanged — still enforced by the separate `runic` CI job (`fredrikekre/runic-action`).
- Drop the now-unused `r-lib/actions/setup-r` step from the workflow and the dead `~/.cache/R/renv` cache path from the composite action.

## Result

Locally, `pre-commit run --all-files` now completes in **~6s cold** (only two small hook environments to build), with all checks passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)